### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/ui/web_dashboard/app.py
+++ b/ui/web_dashboard/app.py
@@ -65,7 +65,7 @@ def create_app(
             
         except Exception as e:
             logger.error(f"Failed to get status: {e}")
-            return jsonify({'error': str(e)}), 500
+            return jsonify({'error': 'An internal error has occurred.'}), 500
     
     @app.route('/api/logs')
     def get_logs():
@@ -88,6 +88,6 @@ def create_app(
             
         except Exception as e:
             logger.error(f"Failed to get logs: {e}")
-            return jsonify({'error': str(e)}), 500
+            return jsonify({'error': 'An internal error has occurred.'}), 500
     
     return app 


### PR DESCRIPTION
Potential fix for [https://github.com/AkCodes23/JARVIS/security/code-scanning/2](https://github.com/AkCodes23/JARVIS/security/code-scanning/2)

To fix the issue, we will replace the exposed exception message (`str(e)`) with a generic error message for the user. The detailed exception information will be logged on the server for debugging purposes. This approach ensures that sensitive information is not exposed to the user while still allowing developers to diagnose issues using the logs.

Specifically:
1. Replace `{'error': str(e)}` with a generic error message like `{'error': 'An internal error has occurred.'}` in the response.
2. Ensure the detailed exception information (`str(e)`) is logged using the existing `logger.error` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
